### PR TITLE
remove grape from dependencies

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -62,7 +62,7 @@ Dependencies := rec(
   GAP := ">= 4.11",
   NeededOtherPackages := [  ],
   SuggestedOtherPackages := [ ],
-  ExternalConditions := [ ["grape", ">=4.8.3"] ],
+  ExternalConditions := [ ],
 ),
 
 AvailabilityTest := ReturnTrue,


### PR DESCRIPTION
grape is only needed for tests, not for the algorithm to work on runtime.
This was discussed in Issue #21 