### PR TITLE
add prefix LINS to all private methods

### DIFF
--- a/gap/LINS.gd
+++ b/gap/LINS.gd
@@ -25,7 +25,7 @@ DeclareGlobalFunction( "LowIndexNormal" );
 #! @Returns a boolean
 #! @Arguments H, G
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "IsSubgroupFp" );
+DeclareGlobalFunction( "LINS_IsSubgroupFp" );
 
 #! @Description
 #! Adds the group <A>H</A> to the list <A>GroupsFound</A>.
@@ -39,7 +39,7 @@ DeclareGlobalFunction( "IsSubgroupFp" );
 #! @Returns [list, positive integer]
 #! @Arguments GroupsFound, H, Supers, test
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "AddGroup" );
+DeclareGlobalFunction( "LINS_AddGroup" );
 
 #! @Description
 #! Let the group G be located in the list <A>GroupsFound</A> at position 1.
@@ -47,7 +47,7 @@ DeclareGlobalFunction( "AddGroup" );
 #! Calculate every normal subgroup K of G, such that the quotient H/K is
 #! isomorphic to some non-abelian group Q, where QQ has stored some information about Q,
 #! and the index [G:K] is less equal <A>n</A>,
-#! and add any such group K to the List <A>GroupsFound</A> by calling the AddGroup-function.
+#! and add any such group K to the List <A>GroupsFound</A> by calling the LINS_AddGroup-function.
 #!
 #! The pregenerated list QQ will contain the following information in form of tupels of any such group Q
 #! with group order up to the maximum index boundary max_index.
@@ -62,24 +62,24 @@ DeclareGlobalFunction( "AddGroup" );
 #! @Returns
 #! @Arguments GroupsFound, n, Current, QQ
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "FindTQuotients" );
+DeclareGlobalFunction( "LINS_FindTQuotients" );
 
 #! @Description
 #! Let <A>n</A> be the maximal index, <A>p</A> a prime,
-#! <A>index</A> the index of some group H and <A>minSubSizes</A> the sizes computed by a call of MinSubgroupSizes on H.
+#! <A>index</A> the index of some group H and <A>minSubSizes</A> the sizes computed by a call of LINS_MinSubgroupSizes on H.
 #! This function checks if <A>p</A>-Quotients have to be computed.
 #! Otherwise the groups can be expressed as Intersections of bigger groups.
 #! @Returns a boolean
 #! @Arguments n, p, index, minSubSizes
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "MustCheckP" );
+DeclareGlobalFunction( "LINS_MustCheckP" );
 
 #! @Description
 #! Let the group G be located in the list <A>GroupsFound</A> at position 1.
 #! Let the group H be located in the list <A>GroupsFound</A> at position <A>Current</A>.
 #! Calculate every normal subgroup K of G, such that <A>H</A>/K is a <A>p</A>-Group
 #! and the index in G is less equal <A>n</A>,
-#! and add any such group K to the List <A>GroupsFound</A> by calling the AddGroup-function.
+#! and add any such group K to the List <A>GroupsFound</A> by calling the LINS_AddGroup-function.
 #!
 #! We construct a module over the groupring (F_<A>p</A> G) and compute maximal submodules of this module.
 #! These submodules can be translated into the subgroups of H we are searching for, namely elementary abelian <A>p</A>-Quotients.
@@ -87,49 +87,49 @@ DeclareGlobalFunction( "MustCheckP" );
 #! @Returns
 #! @Arguments GroupsFound, n, Current, p
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "FindPModules" );
+DeclareGlobalFunction( "LINS_FindPModules" );
 
 #! @Description
 #! Let the group G be located in the list <A>GroupsFound</A> at position 1.
 #! Let the group H be located in the list <A>GroupsFound</A> at position <A>Current</A>.
-#! If MustCheckP return true,
+#! If LINS_MustCheckP return true,
 #! then we calculate every normal subgroup K of G, such that <A>H</A>/K is a p-Group
 #! and the index in G is less equal <A>n</A>,
-#! and add any such group K to the List <A>GroupsFound</A> by calling the AddGroup-function.
+#! and add any such group K to the List <A>GroupsFound</A> by calling the LINS_AddGroup-function.
 #! @Returns
 #! @Arguments GroupsFound, n, Current, p
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "FindPQuotients" );
+DeclareGlobalFunction( "LINS_FindPQuotients" );
 
 #! @Description
 #! @Returns
 #! @Arguments
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "MinSubgroupSizes" );
+DeclareGlobalFunction( "LINS_MinSubgroupSizes" );
 
 #! @Description
 #! @Returns
 #! @Arguments
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "IsPowerOf" );
+DeclareGlobalFunction( "LINS_IsPowerOf" );
 
 #! @Description
 #! @Returns
 #! @Arguments
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "OGL" );
+DeclareGlobalFunction( "LINS_OGL" );
 
 #! @Description
 #! @Returns
 #! @Arguments
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "ExponentSum" );
+DeclareGlobalFunction( "LINS_ExponentSum" );
 
 #! @Description
 #! @Returns
 #! @Arguments
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "PullBackH" );
+DeclareGlobalFunction( "LINS_PullBackH" );
 
 #! @Description
 #! Let the group G be located in the list <A>GroupsFound</A> at position 1.
@@ -137,8 +137,8 @@ DeclareGlobalFunction( "PullBackH" );
 #! Calculate all pairwise intersections of the group H
 #! with all other groups in the list <A>GroupsFound</A> that are stored before the position <A>Current</A>.
 #! Add any normal subgroup found as an intersection and index in G less equal <A>n</A>,
-#! by calling the AddGroup-function.
+#! by calling the LINS_AddGroup-function.
 #! @Returns
 #! @Arguments GroupsFound, n, Current
 #! @ChapterInfo LINS, LINS
-DeclareGlobalFunction( "FindIntersections" );
+DeclareGlobalFunction( "LINS_FindIntersections" );

--- a/gap/LINS.gi
+++ b/gap/LINS.gi
@@ -117,14 +117,14 @@ InstallGlobalFunction( LowIndexNormal, function(G, n)
   Current := 1;
 
   # Call T-Quotient Procedure on G
-  GroupsFound := FindTQuotients(GroupsFound, n, Current, TargetsQuotient);
+  GroupsFound := LINS_FindTQuotients(GroupsFound, n, Current, TargetsQuotient);
 
   while Current <= Length(GroupsFound) and GroupsFound[Current].Index <= (n / 2) do
     # Search for possible P-Quotients
-    GroupsFound := FindPQuotients(GroupsFound, n, Current);
+    GroupsFound := LINS_FindPQuotients(GroupsFound, n, Current);
     # Search for possible Intersections
     if Current > 1 then
-      GroupsFound := FindIntersections(GroupsFound, n, Current);
+      GroupsFound := LINS_FindIntersections(GroupsFound, n, Current);
     fi;
     # Search for normal subgroups in the next group
     Current := Current + 1;

--- a/gap/addGroup.gi
+++ b/gap/addGroup.gi
@@ -16,7 +16,7 @@
 ## Both H and G must be subgroups of the same finitely presented group.
 ## We need coset tables of both H and G in the supergroup.
 ##
-InstallGlobalFunction(IsSubgroupFp, function(G, H)
+InstallGlobalFunction(LINS_IsSubgroupFp, function(G, H)
   local word;
   for word in AugmentedCosetTableInWholeGroup(H).primaryGeneratorWords do
     if RewriteWord(AugmentedCosetTableInWholeGroup(G), word) = fail then
@@ -34,7 +34,7 @@ end);
 ## All references to positions of supergroups will get updated in the list GroupsFound.
 ## The function returns a tupel with the updated list and the position where H can be found in the new list.
 ##
-InstallGlobalFunction(AddGroup, function(GroupsFound, H, Supers, test)
+InstallGlobalFunction(LINS_AddGroup, function(GroupsFound, H, Supers, test)
   local
     G,                      # the parent group, which is stored at the first position in GroupsFound
     NewGroupsFound,         # the updated list of groups after insertion of H
@@ -57,7 +57,7 @@ InstallGlobalFunction(AddGroup, function(GroupsFound, H, Supers, test)
     NewGroupsFound[Current] := K;
     # If test is true, then check if the group H is already contained in the list GroupsFound.
     if test and K.Index = Index(G,H) then
-      if IsSubgroupFp(K.Group,H) then
+      if LINS_IsSubgroupFp(K.Group,H) then
         UniteSet(K.Supergroups,Supers);
         return [GroupsFound,Current];
       fi;
@@ -87,7 +87,7 @@ InstallGlobalFunction(AddGroup, function(GroupsFound, H, Supers, test)
     K := NewGroupsFound[Current];
     if not (Current in H.Supergroups) then
       if H.Index mod K.Index = 0 then
-        if IsSubgroupFp(K.Group,H.Group) then
+        if LINS_IsSubgroupFp(K.Group,H.Group) then
           UniteSet(H.Supergroups,Concatenation([Current],NewGroupsFound[Current].Supergroups));
         fi;
       fi;
@@ -99,7 +99,7 @@ InstallGlobalFunction(AddGroup, function(GroupsFound, H, Supers, test)
     K := NewGroupsFound[Current];
     if not (Position in K.Supergroups) then
       if K.Index mod H.Index = 0 then
-        if IsSubgroupFp(H.Group,K.Group) then
+        if LINS_IsSubgroupFp(H.Group,K.Group) then
           AddSet(K.Supergroups,Position);
           for Subs in Filtered([Current+1..Length(NewGroupsFound)], i -> Current in NewGroupsFound[i].Supergroups) do
             AddSet(NewGroupsFound[Subs].Supergroups,Position);

--- a/gap/findIntersections.gi
+++ b/gap/findIntersections.gi
@@ -17,10 +17,10 @@
 ## Calculate all pairwise intersections of the group H
 ## with all other groups in the list GroupsFound that are stored before the position Current.
 ## Add any normal subgroup found as an intersection and index in G less equal n,
-## by calling the addGroup-function
+## by calling the LINS_AddGroup-function
 ##
 
-InstallGlobalFunction( FindIntersections, function(GroupsFound, n, Current)
+InstallGlobalFunction( LINS_FindIntersections, function(GroupsFound, n, Current)
   local
     H,          # the group (record) at postion Current
     Other,      # Loop variable, position of group to insersect
@@ -61,7 +61,7 @@ InstallGlobalFunction( FindIntersections, function(GroupsFound, n, Current)
     fi;
 
     # Add the intersection to the list GroupsFound
-    GroupsFound := AddGroup(GroupsFound, Intersection(H.Group,K.Group), [Other,Current], false)[1];
+    GroupsFound := LINS_AddGroup(GroupsFound, Intersection(H.Group,K.Group), [Other,Current], false)[1];
   od;
 
   # Return the updated list GroupsFound

--- a/gap/findPModules.gi
+++ b/gap/findPModules.gi
@@ -14,7 +14,7 @@
 ##
 ## Calculate the exponent sum n-size vector of word in Fp
 ##
-InstallGlobalFunction(ExponentSum, function(n,p,word)
+InstallGlobalFunction(LINS_ExponentSum, function(n,p,word)
   local
     rep,      # exponent Representaton of word, that are tupels (a,b), such that a^b is a subword of word
     i,        # loop variable
@@ -34,8 +34,8 @@ end);
 ## Calculate the GroupHomomorphism into the symmetric group
 ## representing the action of H on H/K by multiplication
 ##
-InstallGlobalFunction(PullBackH, function(GenM,p,Gens,O,Mu,Psi)
-  return List([1..Length(Gens)],i->PermList(List([1..Length(O)],j->Position(O,O[j]+(ExponentSum(Length(GenM),p,Gens[i]^Mu))^Psi))));
+InstallGlobalFunction(LINS_PullBackH, function(GenM,p,Gens,O,Mu,Psi)
+  return List([1..Length(Gens)],i->PermList(List([1..Length(O)],j->Position(O,O[j]+(LINS_ExponentSum(Length(GenM),p,Gens[i]^Mu))^Psi))));
 end);
 
 ##
@@ -53,7 +53,7 @@ LINS_maxPGenerators := 1000;
 ## These submodules can be translated into the subgroups of H we are searching for, namely elementary abelian p-Quotients.
 ## Then we call the method on the found subgroups so we compute all p-Quotients and not only the elementary abelian ones.
 ##
-InstallGlobalFunction(FindPModules, function(GroupsFound, n, Current, p)
+InstallGlobalFunction(LINS_FindPModules, function(GroupsFound, n, Current, p)
   local
     G,        # the parent group, which is stored at the first position in GroupsFound
     H,        # the group (record) at position Current
@@ -114,7 +114,7 @@ InstallGlobalFunction(FindPModules, function(GroupsFound, n, Current, p)
     for y in GenM do
       y := PreImagesRepresentative(Iso,PreImagesRepresentative(Mu,y));
       word := Image(Mu, Image(Iso, x*y*x^(-1) ));
-      Add(gen, ExponentSum(Length(GenM),p,word));
+      Add(gen, LINS_ExponentSum(Length(GenM),p,word));
     od;
     Add(gens,gen);
   od;
@@ -141,16 +141,16 @@ InstallGlobalFunction(FindPModules, function(GroupsFound, n, Current, p)
     GenIH := GeneratorsOfGroup(IH);
 
     # Calculate the subgroup K with H/K being an elementary abelian p-Group
-    PhiHom :=  GroupHomomorphismByImagesNC(H,SymmetricGroup(Length(O)),PullBackH(GenM,p,List(GeneratorsOfGroup(H),x->Image(Iso,x)),O,Mu,PsiHom));
+    PhiHom :=  GroupHomomorphismByImagesNC(H,SymmetricGroup(Length(O)),LINS_PullBackH(GenM,p,List(GeneratorsOfGroup(H),x->Image(Iso,x)),O,Mu,PsiHom));
     K := Kernel(PhiHom);
 
-    # Add the subgroup K by calling the addGroup-function
+    # Add the subgroup K by calling the LINS_AddGroup-function
     if Index(G, K) <= n then
-      NewGroup := AddGroup(GroupsFound,K,SSortedList([1,Current]),true);
+      NewGroup := LINS_AddGroup(GroupsFound,K,SSortedList([1,Current]),true);
       GroupsFound := NewGroup[1];
       # If the index is sufficient small, compute p-Quotients from the subgroup K
       if p <= n / Index(G, K) then
-        GroupsFound := FindPModules(GroupsFound, n, NewGroup[2], p);
+        GroupsFound := LINS_FindPModules(GroupsFound, n, NewGroup[2], p);
       fi;
     fi;
   od;

--- a/gap/findPQuotients.gi
+++ b/gap/findPQuotients.gi
@@ -17,7 +17,7 @@
 ## Calculate every normal subgroup K of G, such that H/K is a p-Group
 ## and the index in G is less equal n.
 ##
-InstallGlobalFunction(FindPQuotients, function(GroupsFound, n, Current)
+InstallGlobalFunction(LINS_FindPQuotients, function(GroupsFound, n, Current)
   local
     G,      # the parent group, which is stored at the first position in GroupsFound
     H,      # the group (record) at position Current
@@ -32,9 +32,9 @@ InstallGlobalFunction(FindPQuotients, function(GroupsFound, n, Current)
   while p <= n / Index(G, H) do
 
     # Check according to some rules whether the p-Quotients will be computed by Intersections.
-    if( MustCheckP(n, p, Index(G, H), MinSubgroupSizes(GroupsFound, Current)) ) then
+    if( LINS_MustCheckP(n, p, Index(G, H), LINS_MinSubgroupSizes(GroupsFound, Current)) ) then
       # Compute all p-Groups from H.
-      GroupsFound := FindPModules(GroupsFound, n, Current, p);
+      GroupsFound := LINS_FindPModules(GroupsFound, n, Current, p);
     fi;
 
     # Check the next prime.

--- a/gap/findTQuotients.gi
+++ b/gap/findTQuotients.gi
@@ -17,7 +17,7 @@
 ## Calculate every normal subgroup K of G, such that the quotient H/K is
 ## isomorphic to some non-abelian group Q, where QQ has stored some information about Q,
 ## and the index [G:K] is less equal n,
-## and add any such group K to the List GroupsFound by calling the AddGroup-function.
+## and add any such group K to the List GroupsFound by calling the LINS_AddGroup-function.
 ##
 ##
 ## The pregenerated list QQ will contain the following information in form of tupels of any such group Q
@@ -31,7 +31,7 @@
 ## In order to find the subgroup L of H, the Low-Index-Subgroups-Procedure will calculate every subgroup of H
 ## up to some sufficient large enough index.
 ##
-InstallGlobalFunction( FindTQuotients, function(GroupsFound, n, Current, QQ)
+InstallGlobalFunction( LINS_FindTQuotients, function(GroupsFound, n, Current, QQ)
   local
     G,      # the parent group, which is stored at the first position in GroupsFound
     H,      # the group (record) at position Current
@@ -73,14 +73,14 @@ InstallGlobalFunction( FindTQuotients, function(GroupsFound, n, Current, QQ)
 
   # Search every subgroup L with an index in G contained in I.
   # Then calculate the core of L and try to add the new Group
-  # to the list GroupsFound by calling AddGroup-function
+  # to the list GroupsFound by calling LINS_AddGroup-function
   for L in LL do
     PL := PreImage(Iso, L);
     for i in I do
       if Index(G,PL) = i then
         K := Core(G, PL);
         if Index(G,K) <= n then
-          GroupsFound := AddGroup(GroupsFound,K,[1],true)[1];
+          GroupsFound := LINS_AddGroup(GroupsFound,K,[1],true)[1];
         fi;
         break;
       fi;

--- a/gap/mustCheckP.gi
+++ b/gap/mustCheckP.gi
@@ -14,7 +14,7 @@
 ## This finds the sizes of the minimal normal subgroups of
 ## G/H, where H is the group in the position Current in the list.
 ##
-InstallGlobalFunction(MinSubgroupSizes, function(GroupsFound, Current)
+InstallGlobalFunction(LINS_MinSubgroupSizes, function(GroupsFound, Current)
   local m, minSupergroups;
 
   m := GroupsFound[Current].Supergroups;
@@ -25,7 +25,7 @@ end);
 
 ## For positive integers a,b
 ## return true if a is some power of b;
-InstallGlobalFunction(IsPowerOf, function(a, b)
+InstallGlobalFunction(LINS_IsPowerOf, function(a, b)
   local c;
 
   c := a;
@@ -42,7 +42,7 @@ end);
 ##
 ## This function returns the size of the group GL(r,p).
 ##
-InstallGlobalFunction(OGL, function(r, p)
+InstallGlobalFunction(LINS_OGL, function(r, p)
   local i,j;
 
   i := 1;
@@ -55,13 +55,13 @@ end);
 
 ##
 ## This function checks if p-Quotients have to be computed. Otherwise the groups can be expressed as Intersections of bigger groups.
-## n is the maximal index, p a prime, index is the index of some group H and minSubSizes are the sizes computed by a call of MinSubgroupSizes on H.
+## n is the maximal index, p a prime, index is the index of some group H and minSubSizes are the sizes computed by a call of LINS_MinSubgroupSizes on H.
 ##
-InstallGlobalFunction(MustCheckP, function(n, p, index, minSubSizes)
+InstallGlobalFunction(LINS_MustCheckP, function(n, p, index, minSubSizes)
   local i,j, ordersToCheck, r;
 
   for i in minSubSizes do
-    if IsPowerOf(i, p) then
+    if LINS_IsPowerOf(i, p) then
       return false;
     fi;
   od;
@@ -80,7 +80,7 @@ InstallGlobalFunction(MustCheckP, function(n, p, index, minSubSizes)
   while p^(r+1) <= n / index do
     r := r+1;
   od;
-  if OGL(r, p) mod index = 0 then
+  if LINS_OGL(r, p) mod index = 0 then
     return true;
   fi;
 


### PR DESCRIPTION
One of the standard tests failed when all GAP packages are loaded and it seems that ExponentSum is defined by a different package as well

This commit should fix this issue.