### PR TITLE
Rename LinsNode operations.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,31 +3,43 @@ name: CI
 # Trigger the workflow on push or pull request
 on:
   push:
-    branches: ['master']
+    branches:
+      - master
   pull_request:
+
+# the `concurrency` settings ensure that not too many CI jobs run in parallel
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }} - HPCGAP ${{ matrix.HPCGAP }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.gap-branch }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         gap-branch:
           - master
           - stable-4.11
-        HPCGAP: ['no']
 
     steps:
-      - uses: fkirc/skip-duplicate-actions@master
-      - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap-for-packages@v1
+      - uses: actions/checkout@v3
+      - uses: gap-actions/setup-gap@v2
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
-          HPCGAP: ${{ matrix.HPCGAP }}
           GAP_PKGS_TO_BUILD: "io profiling grape cohomolo"
-      - uses: gap-actions/run-test-for-packages@v1
+      - uses: gap-actions/build-pkg@v1
+      - uses: gap-actions/run-pkg-tests@v2
+        with:
+          GAP_TESTFILE: tst/testall.g
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v3
 
   # The documentation job
   manual:
@@ -35,13 +47,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap-for-packages@v1
-      - uses: gap-actions/compile-documentation-for-packages@v1
+      - uses: actions/checkout@v3
+      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'
-      - name: 'Upload documentation'
-        uses: actions/upload-artifact@v1
+      - name: "Upload documentation"
+        uses: actions/upload-artifact@v3
         with:
           name: manual
           path: ./doc/manual.pdf

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest]
         gap-branch:
           - master
-          - stable-4.11
+          - stable-4.12
 
     steps:
       - uses: actions/checkout@v3

--- a/doc/lins_interface.xml
+++ b/doc/lins_interface.xml
@@ -64,10 +64,10 @@ Returns the index <M>[G : H]</M>.
 </Description>
 </ManSection>
 
-<#Include Label="MinimalSupergroups">
-<#Include Label="MinimalSubgroups">
-<#Include Label="Supergroups">
-<#Include Label="Subgroups">
+<#Include Label="LinsNodeMinimalSupergroups">
+<#Include Label="LinsNodeMinimalSubgroups">
+<#Include Label="LinsNodeSupergroups">
+<#Include Label="LinsNodeSubgroups">
 
 </Section>
 

--- a/gap/LINS.gd
+++ b/gap/LINS.gd
@@ -53,9 +53,9 @@ DeclareAttribute( "Grp", IsLinsNode, "mutable" ); # already defined in recog
 
 DeclareAttribute( "Index", IsLinsNode, "mutable" ); # already defined in GAP
 
-## <#GAPDoc Label="MinimalSupergroups">
+## <#GAPDoc Label="LinsNodeMinimalSupergroups">
 ## <ManSection>
-## <Attr Name="MinimalSupergroups" Arg="rH"/>
+## <Attr Name="LinsNodeMinimalSupergroups" Arg="rH"/>
 ## <Description>
 ##   Let <M>G</M> be the group contained in the root node
 ##   and <M>H</M> be the <M>G</M>-normal subgroup contained in <A>rH</A>. <P/>
@@ -64,11 +64,11 @@ DeclareAttribute( "Index", IsLinsNode, "mutable" ); # already defined in GAP
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
-DeclareAttribute( "MinimalSupergroups", IsLinsNode, "mutable" );
+DeclareAttribute( "LinsNodeMinimalSupergroups", IsLinsNode, "mutable" );
 
-## <#GAPDoc Label="MinimalSubgroups">
+## <#GAPDoc Label="LinsNodeMinimalSubgroups">
 ## <ManSection>
-## <Attr Name="MinimalSubgroups" Arg="rH"/>
+## <Attr Name="LinsNodeMinimalSubgroups" Arg="rH"/>
 ## <Description>
 ##   Let <M>G</M> be the group contained in the root node
 ##   and <M>H</M> be the <M>G</M>-normal subgroup contained in <A>rH</A>. <P/>
@@ -77,14 +77,14 @@ DeclareAttribute( "MinimalSupergroups", IsLinsNode, "mutable" );
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
-DeclareAttribute( "MinimalSubgroups", IsLinsNode, "mutable" );
+DeclareAttribute( "LinsNodeMinimalSubgroups", IsLinsNode, "mutable" );
 
-DeclareAttribute( "TriedPrimes", IsLinsNode, "mutable" );
-DeclareProperty( "IsCut", IsLinsNode, "mutable" );
+DeclareAttribute( "LinsNodeTriedPrimes", IsLinsNode, "mutable" );
+DeclareProperty( "LinsNodeIsCut", IsLinsNode, "mutable" );
 
-## <#GAPDoc Label="Supergroups">
+## <#GAPDoc Label="LinsNodeSupergroups">
 ## <ManSection>
-## <Oper Name="Supergroups" Arg="rH"/>
+## <Oper Name="LinsNodeSupergroups" Arg="rH"/>
 ## <Description>
 ##   Let <M>G</M> be the group contained in the root node
 ##   and <M>H</M> be the <M>G</M>-normal subgroup contained in <A>rH</A>. <P/>
@@ -93,11 +93,11 @@ DeclareProperty( "IsCut", IsLinsNode, "mutable" );
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
-DeclareOperation( "Supergroups", [IsLinsNode]);
+DeclareOperation( "LinsNodeSupergroups", [IsLinsNode]);
 
-## <#GAPDoc Label="Subgroups">
+## <#GAPDoc Label="LinsNodeSubgroups">
 ## <ManSection>
-## <Oper Name="Subgroups" Arg="rH"/>
+## <Oper Name="LinsNodeSubgroups" Arg="rH"/>
 ## <Description>
 ##   Let <M>G</M> be the group contained in the root node
 ##   and <M>H</M> be the <M>G</M>-normal subgroup contained in <A>rH</A>. <P/>
@@ -106,7 +106,7 @@ DeclareOperation( "Supergroups", [IsLinsNode]);
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
-DeclareOperation( "Subgroups", [IsLinsNode]);
+DeclareOperation( "LinsNodeSubgroups", [IsLinsNode]);
 
 
 #############################################################################

--- a/gap/LINS.gi
+++ b/gap/LINS.gi
@@ -54,22 +54,22 @@ function(r)
     return r!.Index;
 end);
 
-InstallMethod( MinimalSupergroups, "for Lins Node", [ IsLinsNode],
+InstallMethod( LinsNodeMinimalSupergroups, "for Lins Node", [ IsLinsNode],
 function(r)
     return r!.MinimalSupergroups;
 end);
 
-InstallMethod( MinimalSubgroups, "for Lins Node", [ IsLinsNode],
+InstallMethod( LinsNodeMinimalSubgroups, "for Lins Node", [ IsLinsNode],
 function(r)
     return r!.MinimalSubgroups;
 end);
 
-InstallMethod( TriedPrimes, "for Lins Node", [ IsLinsNode ],
+InstallMethod( LinsNodeTriedPrimes, "for Lins Node", [ IsLinsNode ],
 function(r)
     return r!.TriedPrimes;
 end);
 
-InstallMethod( IsCut, "for Lins Node", [ IsLinsNode ],
+InstallMethod( LinsNodeIsCut, "for Lins Node", [ IsLinsNode ],
 function(r)
     if IsBound(r!.IsCut) then
         return r!.IsCut;
@@ -82,8 +82,8 @@ InstallOtherMethod( LinsRoot, "for Lins Node", [ IsLinsNode ],
 function(r)
     local s;
     s := r;
-    while not IsEmpty(MinimalSupergroups(s)) do
-        s := MinimalSupergroups(s)[1];
+    while not IsEmpty(LinsNodeMinimalSupergroups(s)) do
+        s := LinsNodeMinimalSupergroups(s)[1];
     od;
     return s;
 end);
@@ -106,14 +106,14 @@ function(r, next)
     return allNodes;
 end);
 
-InstallMethod( Supergroups, "for Lins Node", [ IsLinsNode],
+InstallMethod( LinsNodeSupergroups, "for Lins Node", [ IsLinsNode],
 function(r)
-    return LINS_allNodes(r, MinimalSupergroups);
+    return LINS_allNodes(r, LinsNodeMinimalSupergroups);
 end);
 
-InstallMethod( Subgroups, "for Lins Node", [ IsLinsNode],
+InstallMethod( LinsNodeSubgroups, "for Lins Node", [ IsLinsNode],
 function(r)
-    return LINS_allNodes(r, MinimalSubgroups);
+    return LINS_allNodes(r, LinsNodeMinimalSubgroups);
 end);
 
 
@@ -288,7 +288,7 @@ end);
 #############################################################################
 ####=====================================================================####
 ##
-## Low Index Normal Subgroups (Search Graph)
+## Low Index Normal LinsNodeSubgroups (Search Graph)
 ##
 ####=====================================================================####
 #############################################################################

--- a/gap/LINS.gi
+++ b/gap/LINS.gi
@@ -88,7 +88,7 @@ function(r)
     return s;
 end);
 
-BindGlobal( "LINS_allNodes",
+BindGlobal( "LINS_AllNodes",
 function(r, next)
     local queue, s, t, nextNodes, allNodes;
     queue := [r];
@@ -108,12 +108,12 @@ end);
 
 InstallMethod( LinsNodeSupergroups, "for Lins Node", [ IsLinsNode],
 function(r)
-    return LINS_allNodes(r, LinsNodeMinimalSupergroups);
+    return LINS_AllNodes(r, LinsNodeMinimalSupergroups);
 end);
 
 InstallMethod( LinsNodeSubgroups, "for Lins Node", [ IsLinsNode],
 function(r)
-    return LINS_allNodes(r, LinsNodeMinimalSubgroups);
+    return LINS_AllNodes(r, LinsNodeMinimalSubgroups);
 end);
 
 

--- a/gap/addGroup.gi
+++ b/gap/addGroup.gi
@@ -62,11 +62,11 @@ end);
 # K < H
 BindGlobal("LINS_AddRelations",
 function(rH, rK)
-    Add(MinimalSupergroups(rK), rH);
-    Add(MinimalSubgroups(rH), rK);
+    Add(LinsNodeMinimalSupergroups(rK), rH);
+    Add(LinsNodeMinimalSubgroups(rH), rK);
     # Stable Sort
-    SortBy(MinimalSupergroups(rK), Index);
-    SortBy(MinimalSubgroups(rH), Index);
+    SortBy(LinsNodeMinimalSupergroups(rK), Index);
+    SortBy(LinsNodeMinimalSubgroups(rH), Index);
 end);
 
 # K < H
@@ -74,28 +74,28 @@ BindGlobal("LINS_RemoveRelations",
 function(rH, rK)
     local pos;
 
-    pos := Position(MinimalSupergroups(rK), rH);
-    Remove(MinimalSupergroups(rK), pos);
-    pos := Position(MinimalSubgroups(rH), rK);
-    Remove(MinimalSubgroups(rH), pos);
+    pos := Position(LinsNodeMinimalSupergroups(rK), rH);
+    Remove(LinsNodeMinimalSupergroups(rK), pos);
+    pos := Position(LinsNodeMinimalSubgroups(rH), rK);
+    Remove(LinsNodeMinimalSubgroups(rH), pos);
 end);
 
 BindGlobal("LINS_UpdateRelations",
 function(rH)
     local subs, supers, toRemove, rK, rL, pair;
 
-    subs := Subgroups(rH);
+    subs := LinsNodeSubgroups(rH);
     toRemove := [];
-    for rK in MinimalSupergroups(rH) do
-        for rL in MinimalSubgroups(rK) do
+    for rK in LinsNodeMinimalSupergroups(rH) do
+        for rL in LinsNodeMinimalSubgroups(rK) do
             if rL in subs then
                 Add(toRemove, [rK, rL]);
             fi;
         od;
     od;
-    supers := Supergroups(rH);
-    for rK in MinimalSubgroups(rH) do
-        for rL in MinimalSupergroups(rK) do
+    supers := LinsNodeSupergroups(rH);
+    for rK in LinsNodeMinimalSubgroups(rH) do
+        for rL in LinsNodeMinimalSupergroups(rK) do
             if rL in supers then
                 Add(toRemove, [rL, rK]);
             fi;
@@ -172,7 +172,7 @@ InstallGlobalFunction(LINS_AddGroup, function(gr, H, Supers, test, opts)
         Add(level.Nodes, rH);
     fi;
 
-    # Search for all possible MinimalSupergroups of `H`.
+    # Search for all possible LinsNodeMinimalSupergroups of `H`.
     allSupergroups := [];
     for level in Reversed(gr!.Levels{[1 .. pos - 1]}) do
         for rK in level.Nodes do
@@ -181,14 +181,14 @@ InstallGlobalFunction(LINS_AddGroup, function(gr, H, Supers, test, opts)
                 if Index(rH) mod Index(rK) = 0 then
                     if LINS_IsSubgroupFp(K, H) then
                         LINS_AddRelations(rK, rH);
-                        allSupergroups := DuplicateFreeList(Concatenation(allSupergroups, [rK], Supergroups(rK)));
+                        allSupergroups := DuplicateFreeList(Concatenation(allSupergroups, [rK], LinsNodeSupergroups(rK)));
                     fi;
                 fi;
             fi;
         od;
     od;
 
-    # Search for all possible MinimalSubgroups of `H`.
+    # Search for all possible LinsNodeMinimalSubgroups of `H`.
     allSubgroups := [];
     SortBy(allSubgroups, Index);
     for level in gr!.Levels{[pos + 1 .. Length(gr!.Levels)]} do
@@ -198,7 +198,7 @@ InstallGlobalFunction(LINS_AddGroup, function(gr, H, Supers, test, opts)
                 if Index(rK) mod Index(rH) = 0 then
                     if LINS_IsSubgroupFp(H, K) then
                         LINS_AddRelations(rH, rK);
-                        allSubgroups := DuplicateFreeList(Concatenation(allSubgroups, [rK], Subgroups(rK)));
+                        allSubgroups := DuplicateFreeList(Concatenation(allSubgroups, [rK], LinsNodeSubgroups(rK)));
                     fi;
                 fi;
             fi;

--- a/gap/findIntersections.gi
+++ b/gap/findIntersections.gi
@@ -71,8 +71,8 @@ InstallGlobalFunction( LINS_FindIntersections, function(gr, rH, opts)
     G := Grp(rG);
     H := Grp(rH);
     n := IndexBound(gr);
-    allSupergroups := Supergroups(rH);
-    allSubgroups := Subgroups(rH);
+    allSupergroups := LinsNodeSupergroups(rH);
+    allSubgroups := LinsNodeSubgroups(rH);
     nrFound := 0;
 
     # Main iteration over all preceding groups in `gr`
@@ -81,7 +81,7 @@ InstallGlobalFunction( LINS_FindIntersections, function(gr, rH, opts)
             if rK = rH then
                 break;
             fi;
-            if IsCut(rK) then
+            if LinsNodeIsCut(rK) then
                 continue;
             fi;
             # If `K` is a supergroup of `H`, then continue.
@@ -91,7 +91,7 @@ InstallGlobalFunction( LINS_FindIntersections, function(gr, rH, opts)
             K := Grp(rK);
 
             # Find the smallest supergroup of `H` and `K`. (which is $HK$)
-            xgroups := Supergroups(rK);
+            xgroups := LinsNodeSupergroups(rK);
             supers := Filtered(allSupergroups, s -> s in xgroups);
             rM := supers[PositionMaximum(List(supers, Index))];
             index := rK!.Index * rH!.Index / rM!.Index;
@@ -102,7 +102,7 @@ InstallGlobalFunction( LINS_FindIntersections, function(gr, rH, opts)
             fi;
 
             # Check if the intersection has been already computed
-            xgroups := Subgroups(rK);
+            xgroups := LinsNodeSubgroups(rK);
             subs := Filtered(allSubgroups, s -> s in xgroups);
             if opts.DoIntersection(gr, rH, rK, index) and not (index in List(subs, Index)) then
                 Info(InfoLINS, 3, LINS_tab3,

--- a/gap/findPQuotients.gi
+++ b/gap/findPQuotients.gi
@@ -87,7 +87,7 @@ InstallGlobalFunction(LINS_MustCheckP, function(rH, n, p)
     index := Index(rH);
 
     # sizes of minimal normal subgroups of $G/H$
-    minSubSizes := List(MinimalSupergroups(rH), rK -> Index(rH) / Index(rK));
+    minSubSizes := List(LinsNodeMinimalSupergroups(rH), rK -> Index(rH) / Index(rK));
 
     # Has the quotient G/H a non-trivial normal `p`-subgroup?
     # If yes, then do not compute `p`-quotients under $H$.
@@ -256,10 +256,10 @@ InstallGlobalFunction(LINS_FindPModules, function(gr, rH, p, opts)
     data;   # tuple:        [`rK`, `isNew`]
 
     # Check if `p`-quotients have been computed already from this group
-    if p in TriedPrimes(rH) then
+    if p in LinsNodeTriedPrimes(rH) then
         return [false, 0];
     fi;
-    AddSet(TriedPrimes(rH), p);
+    AddSet(LinsNodeTriedPrimes(rH), p);
 
     # Initialize data
     n := IndexBound(gr);

--- a/tst/gap/SearchForAll/semidirectProduct.g
+++ b/tst/gap/SearchForAll/semidirectProduct.g
@@ -293,7 +293,7 @@ TestSemidirectProduct := function(n)
                     continue;
                 fi;
                 # pos of intersection
-                pos := PositionProperty(L, x -> Index(x) = index and ForAll(subgroupSelection, i -> L[i] in Supergroups(x)));
+                pos := PositionProperty(L, x -> Index(x) = index and ForAll(subgroupSelection, i -> L[i] in LinsNodeSupergroups(x)));
                 if pos = fail then
                     Error("LINS did not find intersection of the subgroups with index list ", List(subgroupSelection, L[i]!.Index));
                 else


### PR DESCRIPTION
There was a conflict with another package,
namely the name `Subgroups` is
used in `sonata` as an unprotected function in `lib/grpsupp.gi`.